### PR TITLE
Add support for remote creation

### DIFF
--- a/src/repo_smith/repo_smith.py
+++ b/src/repo_smith/repo_smith.py
@@ -71,7 +71,7 @@ def create_repo_smith(
         repo = Repo.clone_from(clone_from, dir)
     else:
         repo = Repo.init(dir, initial_branch="main")
-  
+
     if include_remote_repo:
         local_remote_dir = tempfile.mkdtemp()
         remote_path = os.path.join(local_remote_dir, "remote.git")
@@ -87,7 +87,7 @@ def create_repo_smith(
         if repo is not None:
             repo.git.clear_cache()
         shutil.rmtree(dir)
-    
+
     # Clean up bare repository if created
     if local_remote_dir is not None:
         shutil.rmtree(local_remote_dir, ignore_errors=True)


### PR DESCRIPTION
This PR adds a new parameter, `include_remote_repo`, to the `create_repo_smith` function. When set to True, repo-smith creates temporary directory in the user's system and initialises a bare git repository in it.

create_repo_smith now returns a tuple of 2 RepoSmith objects, one representing the local repository and one representing the remote repository (if any).

Fixes https://github.com/git-mastery/repo-smith/issues/18